### PR TITLE
Allow greater faraday version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    faraday-restrict-ip-addresses (0.1.0)
-      faraday (~> 0.9.0)
+    faraday-restrict-ip-addresses (0.2.0)
+      faraday (~> 0.9, < 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -11,12 +11,12 @@ GEM
       columnize (= 0.9.0)
     columnize (0.9.0)
     diff-lcs (1.2.5)
-    faraday (0.9.1)
+    faraday (0.16.2)
       multipart-post (>= 1.2, < 3)
     metaclass (0.0.2)
     mocha (1.0.0)
       metaclass (~> 0.0.1)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -30,8 +30,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.0)
   byebug
   faraday-restrict-ip-addresses!
   mocha
   rspec
+
+BUNDLED WITH
+   1.17.3

--- a/faraday-restrict-ip-addresses.gemspec
+++ b/faraday-restrict-ip-addresses.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |spec|
-  spec.version = '0.1.1'
-  spec.add_dependency 'faraday', '~>0.9.0'
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.version = '0.2.0'
+  spec.add_dependency 'faraday', '~>0.9', '< 1.0'
   spec.authors = ["Ben Lavender", "Christopher Kintner"]
   spec.description = %q{Restrict the IP addresses Faraday will connect to}
   spec.email = ['ckintner@github.com']

--- a/lib/faraday/restrict_ip_addresses/version.rb
+++ b/lib/faraday/restrict_ip_addresses/version.rb
@@ -1,6 +1,6 @@
 require 'faraday'
 module Faraday
   class RestrictIPAddresses < Faraday::Middleware
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Updating to allow higher faraday version.

Related to https://zendesk.atlassian.net/browse/R5U-682

zendesk_channels cannot be updated to allow a higher faraday version because it depends on this gem which also restricts faraday.

cc @zendesk/classic-upgrade 